### PR TITLE
Fix CI: Skip regression tests if PR is draft and just opened

### DIFF
--- a/.github/workflows/regressiontests.yml
+++ b/.github/workflows/regressiontests.yml
@@ -16,7 +16,7 @@ jobs:
 
   regression_tests:
     name: "Test: ${{ matrix.taskdir }}"
-    if: ${{ github.event.action != 'synchronize' || github.event.pull_request.draft == false }}
+    if: ${{ (github.event.action != 'synchronize' && github.event.action != 'opened') || github.event.pull_request.draft == false }}
     timeout-minutes: 1440
     runs-on: gpuagrohr-01
     container:


### PR DESCRIPTION
<!--

CREATE THE PULL REQUEST AS A DRAFT,
then CI will only run the test suite.

When the test suite passes, mark the PR as ready for review.
This will run the regression tests. Trigger CI commit might be required.

-->
