### PR TITLE
Fix CI: Skip regression tests if PR is draft and just opened

### DIFF
--- a/.github/workflows/regressiontests.yml
+++ b/.github/workflows/regressiontests.yml
@@ -16,7 +16,7 @@ jobs:
 
   regression_tests:
     name: "Test: ${{ matrix.taskdir }}"
-    if: ${{ github.event.action != 'synchronize' || github.event.pull_request.draft == false }}
+    if: ${{ (github.event.action != 'synchronize' && github.event.action != 'opened') || github.event.pull_request.draft == false }}
     timeout-minutes: 1440
     runs-on: gpuagrohr-01
     container:

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -33,7 +33,7 @@ jobs:
     
       - name: Wait for test suite
         uses: blend/require-conditional-status-checks@2022.02.04
-        if: ${{ github.event.action == 'synchronize' && github.event.pull_request.draft == true }}
+        if: ${{ (github.event.action == 'synchronize' || github.event.action == 'opened') && github.event.pull_request.draft == true }}
         with:
           interval: 20s
           timeout: 1440m
@@ -48,7 +48,7 @@ jobs:
     
       - name: Wait for test suite and regression tests
         uses: blend/require-conditional-status-checks@2022.02.04
-        if: ${{ github.event.action != 'synchronize' || github.event.pull_request.draft == false }}
+        if: ${{ (github.event.action != 'synchronize' && github.event.action != 'opened') || github.event.pull_request.draft == false }}
         with:
           interval: 20s
           timeout: 1440m


### PR DESCRIPTION
<!--

CREATE THE PULL REQUEST AS A DRAFT,
then CI will only run the test suite.

When the test suite passes, mark the PR as ready for review.
This will run the regression tests. Trigger CI commit might be required.

-->
